### PR TITLE
Monetary policy for NFT

### DIFF
--- a/mlabs/mlabs-plutus-use-cases.cabal
+++ b/mlabs/mlabs-plutus-use-cases.cabal
@@ -25,6 +25,7 @@ library
                      , bytestring
                      , containers
                      , extra
+                     , freer-simple
                      , mtl
                      , playground-common
                      , plutus-core
@@ -71,6 +72,7 @@ library
         Mlabs.Nft.Logic.Types
         Mlabs.Nft.Contract.Nft
         Mlabs.Nft.Contract.Forge
+        Mlabs.Plutus.Contract.StateMachine
   default-extensions: BangPatterns
                       ExplicitForAll
                       FlexibleContexts
@@ -125,8 +127,11 @@ Test-suite mlabs-plutus-use-cases-tests
   Default-Language:    Haskell2010
   Build-Depends:       base              >=4.9 && <5
                      , data-default
+                     , freer-extras
+                     , freer-simple
                      , lens
                      , mlabs-plutus-use-cases
+                     , mtl
                      , containers
                      , playground-common
                      , plutus-core

--- a/mlabs/src/Mlabs/Lending/Contract/Lendex.hs
+++ b/mlabs/src/Mlabs/Lending/Contract/Lendex.hs
@@ -36,11 +36,9 @@ import           Plutus.Contract
 import qualified Plutus.Contract.StateMachine as SM
 import           Ledger                       hiding (singleton)
 import qualified Ledger.Typed.Scripts         as Scripts
-import           Ledger.Value                 (assetClassValue)
 import           Ledger.Constraints
 import qualified PlutusTx                     as PlutusTx
 import           PlutusTx.Prelude             hiding (Applicative (..), check, Semigroup(..), Monoid(..))
-import qualified PlutusTx.Prelude             as PlutusTx
 
 
 import Mlabs.Emulator.Blockchain

--- a/mlabs/src/Mlabs/Nft/Contract/Forge.hs
+++ b/mlabs/src/Mlabs/Nft/Contract/Forge.hs
@@ -4,10 +4,8 @@ module Mlabs.Nft.Contract.Forge(
   , currencySymbol
 ) where
 
-import Control.Monad.State.Strict (evalStateT)
-
 import PlutusTx.Prelude
-import Ledger (CurrencySymbol)
+import Ledger (CurrencySymbol, Address)
 
 import Ledger.Typed.Scripts (MonetaryPolicy)
 import qualified Plutus.V1.Ledger.Value as Value
@@ -15,23 +13,53 @@ import qualified Plutus.V1.Ledger.Scripts as Scripts
 import qualified Ledger.Typed.Scripts     as Scripts
 import qualified PlutusTx                 as PlutusTx
 import Plutus.V1.Ledger.Contexts
-import Ledger.Constraints
 
 import Mlabs.Nft.Logic.Types
-import Mlabs.Nft.Logic.State
 
-validate :: NftId -> ScriptContext -> Bool
-validate _ _ = True
+{-# INLINABLE validate #-}
+-- | Validation of Minting of NFT-token. We guarantee unqiqueness of NFT
+-- by make the script depend on spending of concrete TxOutRef in the list of inputs.
+-- TxOutRef for the input is specified inside NftId value.
+--
+-- Also we check that
+--
+-- * user mints token that coressponds to the content of NFT (token name is hash of NFT content)
+-- * user spends NFT token to the StateMachine script
+--
+-- First argument is an address of NFT state machine script. We use it to check
+-- that NFT coin was payed to script after minting.
+validate :: Address -> NftId -> ScriptContext -> Bool
+validate stateAddr (NftId token oref) ctx =
+     traceIfFalse "UTXO not consumed"     hasUtxo
+  && traceIfFalse "wrong amount minted"   checkMintedAmount
+  && traceIfFalse "Does not pay to state" paysToState
+  where
+    info = scriptContextTxInfo ctx
+
+    hasUtxo = any (\inp -> txInInfoOutRef inp == oref) $ txInfoInputs info
+
+    checkMintedAmount = case Value.flattenValue (txInfoForge info) of
+      [(cur, tn, val)] -> ownCurrencySymbol ctx == cur && token == tn && val == 1
+      _ -> False
+
+    paysToState = any hasNftToken $ txInfoOutputs info
+
+    hasNftToken TxOut{..} =
+         txOutAddress == stateAddr
+      && txOutValue == Value.singleton (ownCurrencySymbol ctx) token 1
 
 -------------------------------------------------------------------------------
 
-currencyPolicy :: NftId -> MonetaryPolicy
-currencyPolicy nid = Scripts.mkMonetaryPolicyScript $
-  $$(PlutusTx.compile [|| \x -> Scripts.wrapMonetaryPolicy (validate x) ||])
-  `PlutusTx.applyCode` PlutusTx.liftCode nid
+-- | Monetary policy of NFT
+-- First argument is an address of NFT state machine script.
+currencyPolicy :: Address -> NftId -> MonetaryPolicy
+currencyPolicy stateAddr nid = Scripts.mkMonetaryPolicyScript $
+  $$(PlutusTx.compile [|| \x y -> Scripts.wrapMonetaryPolicy (validate x y) ||])
+  `PlutusTx.applyCode` (PlutusTx.liftCode stateAddr)
+  `PlutusTx.applyCode` (PlutusTx.liftCode nid)
 
-currencySymbol :: NftId -> CurrencySymbol
-currencySymbol nid = scriptCurrencySymbol (currencyPolicy nid)
-
-
+-- | Currency symbol of NFT
+-- First argument is an address of NFT state machine script.
+currencySymbol :: Address -> NftId -> CurrencySymbol
+currencySymbol stateAddr nid = scriptCurrencySymbol (currencyPolicy stateAddr nid)
 

--- a/mlabs/src/Mlabs/Nft/Logic/React.hs
+++ b/mlabs/src/Mlabs/Nft/Logic/React.hs
@@ -5,7 +5,7 @@
 {-# OPTIONS_GHC -fobject-code #-}
 {-# OPTIONS_GHC -fno-ignore-interface-pragmas #-}
 {-# OPTIONS_GHC -fno-omit-interface-pragmas #-}
---  |Transition function for NFTs
+-- | Transition function for NFTs
 module Mlabs.Nft.Logic.React where
 
 import Control.Monad.State.Strict (modify', gets)
@@ -21,6 +21,7 @@ import Mlabs.Nft.Logic.Types
 import qualified Mlabs.Data.Maybe as Maybe
 
 {-# INLINABLE react #-}
+-- | State transitions for NFT contract logic.
 react :: Act -> St [Resp]
 react inp = do
   checkInputs inp
@@ -59,6 +60,7 @@ react inp = do
       pure []
 
 {-# INLINABLE checkInputs #-}
+-- | Check inputs for valid values.
 checkInputs :: Act -> St ()
 checkInputs (UserAct _uid act) = case act of
   Buy price newPrice -> do

--- a/mlabs/src/Mlabs/Plutus/Contract/StateMachine.hs
+++ b/mlabs/src/Mlabs/Plutus/Contract/StateMachine.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE NamedFieldPuns #-}
+-- | Missing functions for StateMachine
+module Mlabs.Plutus.Contract.StateMachine(
+  runInitialiseWith
+) where
+
+import Prelude
+
+import           Control.Lens
+import           Control.Monad.Error.Lens
+import           Ledger.Constraints                   (ScriptLookups, mustPayToTheScript)
+import qualified Ledger.Constraints.OffChain          as Constraints
+import qualified Ledger.Typed.Scripts                 as Scripts
+import           Plutus.Contract
+import qualified Plutus.Contract.StateMachine.OnChain as SM
+import qualified PlutusTx                             as PlutusTx
+import Ledger.Value
+
+import Plutus.Contract.StateMachine
+
+-- | Initialise a state machine
+runInitialiseWith ::
+    forall w e state schema input.
+    ( PlutusTx.IsData state
+    , PlutusTx.IsData input
+    , HasTxConfirmation schema
+    , HasWriteTx schema
+    , AsSMContractError e
+    )
+    => StateMachineClient state input
+    -- ^ The state machine
+    -> state
+    -- ^ The initial state
+    -> Value
+    -- ^ The value locked by the contract at the beginning
+    -> ScriptLookups (StateMachine state input)
+    -> TxConstraints (Scripts.RedeemerType (StateMachine state input)) (Scripts.DatumType (StateMachine state input))
+    -> Contract w schema e state
+runInitialiseWith StateMachineClient{scInstance} initialState initialValue customLookups customConstraints = mapError (review _SMContractError) $ do
+    let StateMachineInstance{validatorInstance, stateMachine} = scInstance
+        tx = mustPayToTheScript initialState (initialValue <> SM.threadTokenValue stateMachine) <> customConstraints
+    let lookups = Constraints.scriptInstanceLookups validatorInstance <> customLookups
+    utx <- either (throwing _ConstraintResolutionError) pure (Constraints.mkTx lookups tx)
+    submitTxConfirmed utx
+    pure initialState
+

--- a/mlabs/test/Test/Nft/Init.hs
+++ b/mlabs/test/Test/Nft/Init.hs
@@ -1,14 +1,18 @@
+{-# LANGUAGE DataKinds #-}
 -- | Init blockchain state for tests
 module Test.Nft.Init(
-    checkOptions
+    Script
+  , runScript
+  , checkOptions
   , w1, w2, w3
-  , userAct1, userAct2, userAct3
+  , userAct
   , adaCoin
   , initialDistribution
   , toUserId
-  , nftId
   , nftContent
 ) where
+
+import Control.Monad.Reader
 
 import Prelude
 
@@ -26,10 +30,21 @@ import Plutus.Contract.Test hiding (tx)
 import qualified Plutus.Trace.Emulator as Trace
 
 import Mlabs.Emulator.Types
-import Mlabs.Nft.Logic.Types (UserAct(..), NftId, toNftId)
+import Mlabs.Nft.Logic.Types (UserAct(..), NftId)
 import qualified Mlabs.Nft.Contract.Nft as N
 
 import Test.Utils (next)
+
+import Control.Monad.Freer
+import Plutus.Trace.Effects.RunContract
+import Plutus.Trace.Effects.Waiting
+import Plutus.Trace.Effects.EmulatorControl
+import Plutus.Trace.Effects.EmulatedWalletAPI
+import Control.Monad.Freer.Extras.Log
+import Control.Monad.Freer.Error
+import Plutus.Trace.Emulator
+
+import qualified PlutusTx.Ratio as R
 
 checkOptions :: CheckOptions
 checkOptions = defaultCheckOptions & emulatorConfig . Trace.initialChainState .~ Left initialDistribution
@@ -43,19 +58,34 @@ w3 = Wallet 3
 toUserId :: Wallet -> UserId
 toUserId = UserId . pubKeyHash . walletPubKey
 
--- | Showrtcuts for user actions
-userAct1, userAct2, userAct3 :: UserAct -> Trace.EmulatorTrace ()
-userAct1 act = N.callUserAct nftId w1 act >> next
-userAct2 act = N.callUserAct nftId w2 act >> next
-userAct3 act = N.callUserAct nftId w3 act >> next
+-- | Helper to run the scripts for NFT-contract
+type ScriptM a = ReaderT NftId ( Eff '[RunContract, Waiting, EmulatorControl, EmulatedWalletAPI, LogMsg String, Error EmulatorRuntimeError]) a
+type Script = ScriptM ()
 
-nftId :: NftId
-nftId = toNftId nftContent
+-- | Script runner. It inits NFT by user 1 and provides nft id to all sequent
+-- endpoint calls.
+runScript :: Script -> Trace.EmulatorTrace ()
+runScript script = do
+  nftId <- N.callStartNft w1 $ N.StartParams
+    { sp'content = nftContent
+    , sp'share   = 1 R.% 10
+    , sp'price   = Nothing
+    }
+  next
+  runReaderT script nftId
 
+-- | User action call.
+userAct :: Wallet -> UserAct -> Script
+userAct wal act = do
+  nftId <- ask
+  lift $ N.callUserAct nftId wal act >> next
+
+-- | NFT content for testing.
 nftContent :: ByteString
 nftContent = "Mona Lisa"
 
--- | Initial distribution of wallets for testing
+-- | Initial distribution of wallets for testing.
+-- We have 3 users. All of them get 1000 lovelace at the start.
 initialDistribution :: M.Map Wallet Value
 initialDistribution = M.fromList
   [ (w1, val 1000)

--- a/mlabs/test/Test/Nft/Logic.hs
+++ b/mlabs/test/Test/Nft/Logic.hs
@@ -6,7 +6,6 @@ module Test.Nft.Logic(
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import Plutus.V1.Ledger.Value
 import Plutus.V1.Ledger.Crypto (PubKeyHash(..))
 
 import Mlabs.Emulator.App
@@ -14,10 +13,8 @@ import Mlabs.Emulator.Blockchain
 import Mlabs.Emulator.Types
 
 import Mlabs.Nft.Logic.App
-import Mlabs.Nft.Logic.Types
 
 import qualified Data.Map.Strict as M
-import qualified PlutusTx.Ratio as R
 
 -- | Test suite for a logic of lending application
 test :: TestTree
@@ -57,6 +54,7 @@ initWallets = [(user1, wal), (user2, wal)]
 
 -- buy
 
+-- | Buy script
 buyScript :: Script
 buyScript = do
   setPrice user1 (Just 100)


### PR DESCRIPTION
Implements monetary policy for NFT. We ensure that only single NFT can be minted.
Technique is based on the one provided in Lars's lecture