### PR TITLE
record dot preprocessor added to cabal test-suite ghc-options

### DIFF
--- a/mlabs/mlabs-plutus-use-cases.cabal
+++ b/mlabs/mlabs-plutus-use-cases.cabal
@@ -240,12 +240,50 @@ executable lendex-demo
                      , row-types
                      , vector
   default-language:    Haskell2010
-  default-extensions: AllowAmbiguousTypes BlockArguments BangPatterns ConstraintKinds DataKinds DefaultSignatures DeriveAnyClass DeriveFunctor DeriveGeneric DerivingStrategies DerivingVia DuplicateRecordFields EmptyCase ExplicitNamespaces FlexibleContexts FlexibleInstances GeneralizedNewtypeDeriving InstanceSigs LambdaCase MultiParamTypeClasses MultiWayIf NamedFieldPuns NoImplicitPrelude NumericUnderscores OverloadedLabels OverloadedStrings PatternSynonyms RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskell TupleSections TypeApplications TypeFamilies TypeOperators TypeSynonymInstances UndecidableInstances ViewPatterns ImportQualifiedPost RoleAnnotations
-
+  default-extensions: AllowAmbiguousTypes
+                      BlockArguments
+                      BangPatterns
+                      ConstraintKinds
+                      DataKinds
+                      DefaultSignatures
+                      DeriveAnyClass
+                      DeriveFunctor
+                      DeriveGeneric
+                      DerivingStrategies
+                      DerivingVia
+                      DuplicateRecordFields
+                      EmptyCase
+                      ExplicitNamespaces
+                      FlexibleContexts
+                      FlexibleInstances
+                      GeneralizedNewtypeDeriving
+                      InstanceSigs
+                      LambdaCase
+                      MultiParamTypeClasses
+                      MultiWayIf
+                      NamedFieldPuns
+                      NoImplicitPrelude
+                      NumericUnderscores
+                      OverloadedLabels
+                      OverloadedStrings
+                      PatternSynonyms
+                      RecordWildCards
+                      ScopedTypeVariables
+                      StandaloneDeriving
+                      TemplateHaskell
+                      TupleSections
+                      TypeApplications
+                      TypeFamilies
+                      TypeOperators
+                      TypeSynonymInstances
+                      UndecidableInstances
+                      ViewPatterns
+                      ImportQualifiedPost
+                      RoleAnnotations
 
 Test-suite mlabs-plutus-use-cases-tests
   Type:                exitcode-stdio-1.0
-  Ghc-options:         -Wall -threaded -rtsopts
+  Ghc-options:         -Wall -threaded -rtsopts -fplugin=RecordDotPreprocessor
   Default-Language:    Haskell2010
   Build-Depends:       base              >=4.9 && <5
                      , data-default
@@ -267,6 +305,8 @@ Test-suite mlabs-plutus-use-cases-tests
                      , plutus-contract
                      , prettyprinter
                      , pretty-show
+                     , record-dot-preprocessor
+                     , record-hasfield
                      , tasty
                      , tasty-hunit
                      , tasty-expected-failure
@@ -290,4 +330,3 @@ Test-suite mlabs-plutus-use-cases-tests
     OverloadedStrings
     QuasiQuotes
     TupleSections
-

--- a/mlabs/test/Test/Lending/QuickCheck.hs
+++ b/mlabs/test/Test/Lending/QuickCheck.hs
@@ -1,4 +1,12 @@
-{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE NumericUnderscores    #-}
+{-# LANGUAGE DataKinds             #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE GADTs                 #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications      #-}
+{-# LANGUAGE UndecidableInstances  #-}
 
 module Test.Lending.QuickCheck where
 


### PR DESCRIPTION
Settings and dependencies for record dot preprocessor seems to be missing in test-suite part of .cabal file. Adding missing parts in this PR