### PR TITLE
Include passphrase when calling signing endpoint

### DIFF
--- a/mlabs/src/Mlabs/WbeTest/TestStand.hs
+++ b/mlabs/src/Mlabs/WbeTest/TestStand.hs
@@ -128,4 +128,4 @@ testnetWalletId :: WalletId
 testnetWalletId = "01f9f1dda617eb8bff71468c702afceee5b1ccbf"
 
 clientCfg :: WbeClientCfg
-clientCfg = defaultWbeClientCfg testnetWalletId
+clientCfg = defaultWbeClientCfg testnetWalletId (error "FIXME")

--- a/mlabs/src/Mlabs/WbeTest/Types.hs
+++ b/mlabs/src/Mlabs/WbeTest/Types.hs
@@ -3,6 +3,7 @@
 module Mlabs.WbeTest.Types
 ( WbeExportTx(..),
   WalletId(..),
+  Passphrase(..),
   WbeStage(..),
   WbeTx(..),
   WbeTxSubmitted(..),
@@ -100,6 +101,12 @@ instance ToJSON WbeExportTx where
 
 newtype WalletId = WalletId
   { unWalletId :: Text
+  }
+  deriving stock (Hask.Show, Generic)
+  deriving newtype (Hask.Eq, FromJSON, ToJSON, IsString)
+
+newtype Passphrase = Passphrase
+  { unPassphrase :: Text
   }
   deriving stock (Hask.Show, Generic)
   deriving newtype (Hask.Eq, FromJSON, ToJSON, IsString)


### PR DESCRIPTION
Fix to include the wallet passphrase in signing requests