### PR TITLE
Use nix for CI format/lint

### DIFF
--- a/.github/format.sh
+++ b/.github/format.sh
@@ -1,4 +1,4 @@
 # Extensions necessary to tell fourmolu about 
 EXTENSIONS="-o -XTypeApplications -o -XTemplateHaskell -o -XImportQualifiedPost -o -XPatternSynonyms -o -fplugin=RecordDotPreprocessor"
 SOURCES=$(git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.hs')
-~/.local/bin/fourmolu --mode check --check-idempotence $EXTENSIONS $SOURCES
+fourmolu --mode check --check-idempotence $EXTENSIONS $SOURCES

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -2,9 +2,9 @@ name: Formatting
 
 on:
   push:
-    branches: [ main, staging ]
+    branches: [main, staging]
   pull_request:
-    branches: [ main, staging ]
+    branches: [main, staging]
   workflow_dispatch:
 
 jobs:
@@ -12,16 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/cache@v2.1.4
-        name: Cache Stack
+      - uses: cachix/install-nix-action@v13
+        name: Set up nix
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-formatting
-          restore-keys: ${{ runner.os }}-stack-
+          extra_nix_config: experimental-features = nix-command flakes
 
-      - run: stack install fourmolu
-        name: Setup
-
-      - run: ./.github/format.sh
+      - run: nix shell nixpkgs#haskellPackages.fourmolu -c ./.github/format.sh
         name: "Run fourmolu"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [ main, staging ]
+    branches: [main, staging]
   pull_request:
-    branches: [ main, staging ]
+    branches: [main, staging]
   workflow_dispatch:
 
 jobs:
@@ -12,16 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/cache@v2.1.4
-        name: Cache Stack
+      - uses: cachix/install-nix-action@v13
+        name: Set up nix
         with:
-          path: ~/.stack
-          key: ${{ runner.os }}-stack-lint
-          restore-keys: ${{ runner.os }}-stack-
+          extra_nix_config: experimental-features = nix-command flakes
 
-      - run: stack install hlint
-        name: Setup
-
-      - run: ~/.local/bin/hlint $(git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.hs')
+      - run: |
+          nix shell nixpkgs#haskellPackages.hlint -c hlint \
+            $(git ls-tree -r HEAD --full-tree --name-only | grep -E '.*\.hs')
         name: Lint

--- a/mlabs/test/Test/NFT/QuickCheck.hs
+++ b/mlabs/test/Test/NFT/QuickCheck.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE StrictData #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StrictData #-}
 
 module Test.NFT.QuickCheck where
 


### PR DESCRIPTION
- Get `fourmolu` and `hlint` from Nix instead of Stack
- Fix pragma order in `Test.NFT.QuickCheck`
