### PR TITLE
Rename legacy nft module to avoid name conflict

### DIFF
--- a/mlabs/deploy-app/Main.hs
+++ b/mlabs/deploy-app/Main.hs
@@ -6,9 +6,9 @@ import System.Exit (die)
 import Prelude (IO, String, error, print, undefined)
 
 import Mlabs.Emulator.Types (UserId (..))
-import Mlabs.Nft.Contract.Forge as F
-import Mlabs.Nft.Contract.StateMachine as SM
-import Mlabs.Nft.Logic.Types (Act (..), Nft (..), NftId (..), UserAct (..), initNft, toNftId)
+import Mlabs.NftStateMachine.Contract.Forge as F
+import Mlabs.NftStateMachine.Contract.StateMachine as SM
+import Mlabs.NftStateMachine.Logic.Types (Act (..), Nft (..), NftId (..), UserAct (..), initNft, toNftId)
 
 import Cardano.Api
 import Cardano.Api.Shelley

--- a/mlabs/legacy-nft-endpoint-spec.md
+++ b/mlabs/legacy-nft-endpoint-spec.md
@@ -15,7 +15,7 @@ re-sold, a royalty to the artist can be enforced
 prerequisite: none
 
 input:
-Mlabs.Nft.Contract.Api.StartParams
+Mlabs.NftStateMachine.Contract.Api.StartParams
 (content, share, price)
 
 behavior: instantiates the 'User' Contract, which represents an asset described
@@ -37,7 +37,7 @@ Prerequiste: none beyond contract instantiation
 must be the current owner
 
 input:
-Mlabs.Nft.Contract.Api.SetPrice
+Mlabs.NftStateMachine.Contract.Api.SetPrice
 
 behavior:  
 updates the `price` parameter needed for the `Buy` endpoint
@@ -49,7 +49,7 @@ asking price specified by a call to either `StartParams` or `SetPrice` must be a
 Just.   if it is a Nothing, then the asset is not for sale.
 
 input:
-Mlabs.Nft.Contract.Api.Buy
+Mlabs.NftStateMachine.Contract.Api.Buy
 (price, newprice)
 
 behavior:

--- a/mlabs/mlabs-plutus-use-cases.cabal
+++ b/mlabs/mlabs-plutus-use-cases.cabal
@@ -166,17 +166,17 @@ library
     Mlabs.NFT.PAB.Simulator
     Mlabs.NFT.Types
     Mlabs.NFT.Validation
-    Mlabs.Nft.Contract
-    Mlabs.Nft.Contract.Api
-    Mlabs.Nft.Contract.Emulator.Client
-    Mlabs.Nft.Contract.Forge
-    Mlabs.Nft.Contract.Server
-    Mlabs.Nft.Contract.Simulator.Handler
-    Mlabs.Nft.Contract.StateMachine
-    Mlabs.Nft.Logic.App
-    Mlabs.Nft.Logic.React
-    Mlabs.Nft.Logic.State
-    Mlabs.Nft.Logic.Types
+    Mlabs.NftStateMachine.Contract
+    Mlabs.NftStateMachine.Contract.Api
+    Mlabs.NftStateMachine.Contract.Emulator.Client
+    Mlabs.NftStateMachine.Contract.Forge
+    Mlabs.NftStateMachine.Contract.Server
+    Mlabs.NftStateMachine.Contract.Simulator.Handler
+    Mlabs.NftStateMachine.Contract.StateMachine
+    Mlabs.NftStateMachine.Logic.App
+    Mlabs.NftStateMachine.Logic.React
+    Mlabs.NftStateMachine.Logic.State
+    Mlabs.NftStateMachine.Logic.Types
     Mlabs.Plutus.Contract
     Mlabs.Plutus.PAB
     Mlabs.System.Console.PrettyLogger
@@ -207,13 +207,13 @@ executable deploy-app
     , serialise
     , cardano-api
 
-executable nft-demo
+executable nft-state-machine-demo
   import:  common-imports
   import:  common-language
   import:  common-configs
   import:  common-ghc-options  
 
-  main-is: nft-demo/Main.hs
+  main-is: nft-state-machine-demo/Main.hs
   build-depends: mlabs-plutus-use-cases
 
 executable governance-demo

--- a/mlabs/nft-state-machine-demo/Main.hs
+++ b/mlabs/nft-state-machine-demo/Main.hs
@@ -18,9 +18,9 @@ import Plutus.PAB.Simulator qualified as Simulator
 import PlutusTx.Prelude (BuiltinByteString)
 import Wallet.Emulator.Wallet (fromWalletNumber)
 
-import Mlabs.Nft.Contract qualified as Nft
-import Mlabs.Nft.Contract.Simulator.Handler qualified as Handler
-import Mlabs.Nft.Logic.Types (NftId)
+import Mlabs.NftStateMachine.Contract qualified as Nft
+import Mlabs.NftStateMachine.Contract.Simulator.Handler qualified as Handler
+import Mlabs.NftStateMachine.Logic.Types (NftId)
 import Mlabs.Plutus.PAB (call, printBalance, waitForLast)
 import Mlabs.System.Console.PrettyLogger (logNewLine)
 import Mlabs.System.Console.Utils (logAction, logMlabs)

--- a/mlabs/src/Mlabs/Deploy/Nft.hs
+++ b/mlabs/src/Mlabs/Deploy/Nft.hs
@@ -4,9 +4,9 @@ import PlutusTx.Prelude hiding (error)
 import Prelude (IO, String)
 
 import Mlabs.Emulator.Types (UserId (..))
-import Mlabs.Nft.Contract.Forge as F
-import Mlabs.Nft.Contract.StateMachine as SM
-import Mlabs.Nft.Logic.Types
+import Mlabs.NftStateMachine.Contract.Forge as F
+import Mlabs.NftStateMachine.Contract.StateMachine as SM
+import Mlabs.NftStateMachine.Logic.Types
 
 -- import Data.ByteString.Lazy qualified as LB
 import Ledger.Typed.Scripts.Validators as VS

--- a/mlabs/src/Mlabs/Nft/Contract.hs
+++ b/mlabs/src/Mlabs/Nft/Contract.hs
@@ -1,9 +1,0 @@
--- | Re-export module
-module Mlabs.Nft.Contract (
-  module X,
-) where
-
-import Mlabs.Nft.Contract.Api as X
-import Mlabs.Nft.Contract.Forge as X
-import Mlabs.Nft.Contract.Server as X
-import Mlabs.Nft.Contract.StateMachine as X

--- a/mlabs/src/Mlabs/NftStateMachine/Contract.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Contract.hs
@@ -1,0 +1,9 @@
+-- | Re-export module
+module Mlabs.NftStateMachine.Contract (
+  module X,
+) where
+
+import Mlabs.NftStateMachine.Contract.Api as X
+import Mlabs.NftStateMachine.Contract.Forge as X
+import Mlabs.NftStateMachine.Contract.Server as X
+import Mlabs.NftStateMachine.Contract.StateMachine as X

--- a/mlabs/src/Mlabs/NftStateMachine/Contract/Api.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Contract/Api.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Contract API for Lendex application
-module Mlabs.Nft.Contract.Api (
+module Mlabs.NftStateMachine.Contract.Api (
   Buy (..),
   SetPrice (..),
   StartParams (..),
@@ -22,7 +22,7 @@ import Plutus.Contract (type (.\/))
 import PlutusTx.Prelude (BuiltinByteString, Integer, Maybe, Rational)
 import Prelude qualified as Hask (Eq, Show)
 
-import Mlabs.Nft.Logic.Types (UserAct (BuyAct, SetPriceAct))
+import Mlabs.NftStateMachine.Logic.Types (UserAct (BuyAct, SetPriceAct))
 import Mlabs.Plutus.Contract (Call, IsEndpoint (..))
 
 ----------------------------------------------------------------------

--- a/mlabs/src/Mlabs/NftStateMachine/Contract/Emulator/Client.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Contract/Emulator/Client.hs
@@ -1,5 +1,5 @@
 -- | Client functions to test contracts in EmulatorTrace monad.
-module Mlabs.Nft.Contract.Emulator.Client (
+module Mlabs.NftStateMachine.Contract.Emulator.Client (
   callUserAct,
   callStartNft,
 ) where
@@ -11,9 +11,9 @@ import Data.Monoid (Last (..))
 import Plutus.Trace.Emulator (EmulatorRuntimeError (..), EmulatorTrace, activateContractWallet, observableState, throwError, waitNSlots)
 import Wallet.Emulator (Wallet)
 
-import Mlabs.Nft.Contract.Api (Buy (..), SetPrice (..), StartParams)
-import Mlabs.Nft.Contract.Server (authorEndpoints, userEndpoints)
-import Mlabs.Nft.Logic.Types qualified as Types
+import Mlabs.NftStateMachine.Contract.Api (Buy (..), SetPrice (..), StartParams)
+import Mlabs.NftStateMachine.Contract.Server (authorEndpoints, userEndpoints)
+import Mlabs.NftStateMachine.Logic.Types qualified as Types
 import Mlabs.Plutus.Contract (callEndpoint')
 
 ---------------------------------------------------------

--- a/mlabs/src/Mlabs/NftStateMachine/Contract/Forge.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Contract/Forge.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 
 -- | Validation of forge for NFTs
-module Mlabs.Nft.Contract.Forge (
+module Mlabs.NftStateMachine.Contract.Forge (
   currencyPolicy,
   currencySymbol,
 ) where
@@ -16,7 +16,7 @@ import Plutus.V1.Ledger.Scripts qualified as Scripts
 import Plutus.V1.Ledger.Value qualified as Value
 import PlutusTx qualified
 
-import Mlabs.Nft.Logic.Types (NftId (NftId))
+import Mlabs.NftStateMachine.Logic.Types (NftId (NftId))
 
 {-# INLINEABLE validate #-}
 

--- a/mlabs/src/Mlabs/NftStateMachine/Contract/Server.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Contract/Server.hs
@@ -1,4 +1,4 @@
-module Mlabs.Nft.Contract.Server (
+module Mlabs.NftStateMachine.Contract.Server (
   -- * Contracts
   UserContract,
   AuthorContract,
@@ -21,9 +21,9 @@ import Ledger.Constraints qualified as Constraints
 import Ledger.Tx (ciTxOutDatum)
 import Mlabs.Data.List (firstJustRight)
 import Mlabs.Emulator.Types (ownUserId)
-import Mlabs.Nft.Contract.Api (AuthorSchema, Buy, IsUserAct, SetPrice, StartParams (..), UserSchema, toUserAct)
-import Mlabs.Nft.Contract.StateMachine qualified as SM
-import Mlabs.Nft.Logic.Types (Act (UserAct), NftId, initNft, toNftId)
+import Mlabs.NftStateMachine.Contract.Api (AuthorSchema, Buy, IsUserAct, SetPrice, StartParams (..), UserSchema, toUserAct)
+import Mlabs.NftStateMachine.Contract.StateMachine qualified as SM
+import Mlabs.NftStateMachine.Logic.Types (Act (UserAct), NftId, initNft, toNftId)
 import Mlabs.Plutus.Contract (getEndpoint, selectForever)
 import Plutus.Contract (Contract, logError, ownPubKeyHash, tell, throwError, toContract, utxosAt)
 import Plutus.V1.Ledger.Api (Datum)

--- a/mlabs/src/Mlabs/NftStateMachine/Contract/Simulator/Handler.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Contract/Simulator/Handler.hs
@@ -1,5 +1,5 @@
 -- | Handlers for PAB simulator
-module Mlabs.Nft.Contract.Simulator.Handler (
+module Mlabs.NftStateMachine.Contract.Simulator.Handler (
   Sim,
   NftContracts (..),
   runSimulator,
@@ -43,10 +43,10 @@ import Plutus.PAB.Simulator qualified as Simulator
 -- ! import Plutus.PAB.Types (PABError (..))
 import Plutus.PAB.Webserver.Server qualified as PAB.Server
 
-import Mlabs.Nft.Contract.Api qualified as Nft
+import Mlabs.NftStateMachine.Contract.Api qualified as Nft
 
--- ! import Mlabs.Nft.Contract.Server qualified as Nft
-import Mlabs.Nft.Logic.Types (NftId)
+-- ! import Mlabs.NftStateMachine.Contract.Server qualified as Nft
+import Mlabs.NftStateMachine.Logic.Types (NftId)
 
 -- | Shortcut for Simulator monad for NFT case
 type Sim a = Simulation (Builtin NftContracts) a

--- a/mlabs/src/Mlabs/NftStateMachine/Contract/StateMachine.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Contract/StateMachine.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Mlabs.Nft.Contract.StateMachine (
+module Mlabs.NftStateMachine.Contract.StateMachine (
   NftMachine,
   NftMachineClient,
   NftError,
@@ -38,9 +38,9 @@ import PlutusTx.Prelude qualified as Plutus
 
 import Mlabs.Emulator.Blockchain (toConstraints, updateRespValue)
 import Mlabs.Emulator.Types (UserId (..))
-import Mlabs.Nft.Contract.Forge qualified as Forge
-import Mlabs.Nft.Logic.React (react)
-import Mlabs.Nft.Logic.Types (Act (UserAct), Nft (nft'id), NftId (nftId'token))
+import Mlabs.NftStateMachine.Contract.Forge qualified as Forge
+import Mlabs.NftStateMachine.Logic.React (react)
+import Mlabs.NftStateMachine.Logic.Types (Act (UserAct), Nft (nft'id), NftId (nftId'token))
 
 type NftMachine = SM.StateMachine Nft Act
 type NftMachineClient = SM.StateMachineClient Nft Act

--- a/mlabs/src/Mlabs/NftStateMachine/Logic/App.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Logic/App.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | Application for testing NFT logic.
-module Mlabs.Nft.Logic.App (
+module Mlabs.NftStateMachine.Logic.App (
   NftApp,
   runNftApp,
   AppCfg (..),
@@ -30,8 +30,8 @@ import Mlabs.Emulator.App (App (..), runApp)
 import Mlabs.Emulator.Blockchain (BchState (BchState), BchWallet (..), defaultBchWallet)
 import Mlabs.Emulator.Script qualified as S
 import Mlabs.Emulator.Types (UserId (..), adaCoin)
-import Mlabs.Nft.Logic.React (react)
-import Mlabs.Nft.Logic.Types (Act (..), Nft, UserAct (BuyAct, SetPriceAct), initNft)
+import Mlabs.NftStateMachine.Logic.React (react)
+import Mlabs.NftStateMachine.Logic.Types (Act (..), Nft, UserAct (BuyAct, SetPriceAct), initNft)
 import PlutusTx.Ratio qualified as R
 
 -- | NFT test emulator. We use it test the logic.

--- a/mlabs/src/Mlabs/NftStateMachine/Logic/React.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Logic/React.hs
@@ -5,7 +5,7 @@
 {-# OPTIONS_GHC -fobject-code #-}
 
 -- | Transition function for NFTs
-module Mlabs.Nft.Logic.React (react, checkInputs) where
+module Mlabs.NftStateMachine.Logic.React (react, checkInputs) where
 
 import Control.Monad.State.Strict (gets, modify')
 
@@ -14,8 +14,8 @@ import PlutusTx.Prelude
 import Mlabs.Control.Check (isPositive)
 import Mlabs.Emulator.Blockchain (Resp (Move))
 import Mlabs.Lending.Logic.Types (adaCoin)
-import Mlabs.Nft.Logic.State (St, getAuthorShare, isOwner, isRightPrice)
-import Mlabs.Nft.Logic.Types (
+import Mlabs.NftStateMachine.Logic.State (St, getAuthorShare, isOwner, isRightPrice)
+import Mlabs.NftStateMachine.Logic.Types (
   Act (..),
   Nft (nft'author, nft'owner, nft'price),
   UserAct (BuyAct, SetPriceAct),

--- a/mlabs/src/Mlabs/NftStateMachine/Logic/State.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Logic/State.hs
@@ -5,7 +5,7 @@
 {-# OPTIONS_GHC -fobject-code #-}
 
 -- | State transitions for NFT app
-module Mlabs.Nft.Logic.State (
+module Mlabs.NftStateMachine.Logic.State (
   St,
   isOwner,
   isRightPrice,
@@ -16,7 +16,7 @@ import PlutusTx.Prelude
 
 import Mlabs.Control.Monad.State (PlutusState, gets, guardError)
 import Mlabs.Lending.Logic.Types (UserId)
-import Mlabs.Nft.Logic.Types (Nft (nft'owner, nft'price, nft'share))
+import Mlabs.NftStateMachine.Logic.Types (Nft (nft'owner, nft'price, nft'share))
 import PlutusTx.Ratio qualified as R
 
 -- | State update of NFT

--- a/mlabs/src/Mlabs/NftStateMachine/Logic/Types.hs
+++ b/mlabs/src/Mlabs/NftStateMachine/Logic/Types.hs
@@ -13,7 +13,7 @@
 {-# OPTIONS_GHC -fobject-code #-}
 
 -- | Datatypes for NFT state machine.
-module Mlabs.Nft.Logic.Types (
+module Mlabs.NftStateMachine.Logic.Types (
   Nft (..),
   NftId (..),
   initNft,

--- a/mlabs/test/Test/Nft/Contract.hs
+++ b/mlabs/test/Test/Nft/Contract.hs
@@ -10,7 +10,7 @@ import Test.Nft.Init (Script, adaCoin, checkOptions, runScript, userAct, w1, w2,
 import Test.Tasty (TestTree, testGroup)
 
 import Mlabs.Emulator.Scene (Scene, checkScene, owns)
-import Mlabs.Nft.Logic.Types (UserAct (..))
+import Mlabs.NftStateMachine.Logic.Types (UserAct (..))
 
 test :: TestTree
 test =

--- a/mlabs/test/Test/Nft/Init.hs
+++ b/mlabs/test/Test/Nft/Init.hs
@@ -37,9 +37,9 @@ import PlutusTx.Prelude (BuiltinByteString)
 import Test.Utils (next)
 
 import Mlabs.Emulator.Types (UserId (..), adaCoin)
-import Mlabs.Nft.Contract qualified as N
-import Mlabs.Nft.Contract.Emulator.Client qualified as N
-import Mlabs.Nft.Logic.Types (NftId, UserAct (..))
+import Mlabs.NftStateMachine.Contract qualified as N
+import Mlabs.NftStateMachine.Contract.Emulator.Client qualified as N
+import Mlabs.NftStateMachine.Logic.Types (NftId, UserAct (..))
 import Mlabs.Utils.Wallet (walletFromNumber)
 import PlutusTx.Ratio qualified as R
 

--- a/mlabs/test/Test/Nft/Logic.hs
+++ b/mlabs/test/Test/Nft/Logic.hs
@@ -13,7 +13,7 @@ import Test.Tasty.HUnit (testCase)
 import Mlabs.Emulator.App (checkWallets, noErrors, someErrors)
 import Mlabs.Emulator.Blockchain (BchWallet (..))
 import Mlabs.Emulator.Types (UserId (UserId), adaCoin)
-import Mlabs.Nft.Logic.App (Script, buy, defaultAppCfg, runNftApp, setPrice)
+import Mlabs.NftStateMachine.Logic.App (Script, buy, defaultAppCfg, runNftApp, setPrice)
 
 -- | Test suite for a logic of lending application
 test :: TestTree


### PR DESCRIPTION
Renames the legacy `Nft` folder/module to avoid a conflict with the new `NFT` folder (which caused problems with MacOS).