### PR TITLE
Rename legacy Nft test folder/module

### DIFF
--- a/mlabs/mlabs-plutus-use-cases.cabal
+++ b/mlabs/mlabs-plutus-use-cases.cabal
@@ -298,9 +298,9 @@ Test-suite mlabs-plutus-use-cases-tests
     Test.Lending.Init
     Test.Lending.Logic
     Test.Lending.QuickCheck
-    Test.Nft.Contract
-    Test.Nft.Init
-    Test.Nft.Logic
+    Test.NftStateMachine.Contract
+    Test.NftStateMachine.Init
+    Test.NftStateMachine.Logic
     Test.Utils
     Test.NFT.Init
     Test.NFT.Trace

--- a/mlabs/test/Main.hs
+++ b/mlabs/test/Main.hs
@@ -15,8 +15,8 @@ import Test.NFT.Contract qualified as NFT.Contract
 import Test.NFT.QuickCheck qualified as NFT.QuickCheck
 import Test.NFT.Script.Main qualified as NFT.Script
 import Test.NFT.Size qualified as NFT.Size
-import Test.Nft.Contract qualified as Nft.Contract
-import Test.Nft.Logic qualified as Nft.Logic
+import Test.NftStateMachine.Contract qualified as Nft.Contract
+import Test.NftStateMachine.Logic qualified as Nft.Logic
 
 main :: IO ()
 main =

--- a/mlabs/test/Test/NftStateMachine/Contract.hs
+++ b/mlabs/test/Test/NftStateMachine/Contract.hs
@@ -1,4 +1,4 @@
-module Test.Nft.Contract (
+module Test.NftStateMachine.Contract (
   test,
 ) where
 
@@ -6,7 +6,7 @@ import PlutusTx.Prelude hiding (foldMap, mconcat, (<>))
 import Prelude (foldMap, mconcat, (<>))
 
 import Plutus.Contract.Test (Wallet (..), checkPredicateOptions)
-import Test.Nft.Init (Script, adaCoin, checkOptions, runScript, userAct, w1, w2, w3)
+import Test.NftStateMachine.Init (Script, adaCoin, checkOptions, runScript, userAct, w1, w2, w3)
 import Test.Tasty (TestTree, testGroup)
 
 import Mlabs.Emulator.Scene (Scene, checkScene, owns)

--- a/mlabs/test/Test/NftStateMachine/Init.hs
+++ b/mlabs/test/Test/NftStateMachine/Init.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE NumericUnderscores #-}
 
 -- | Init blockchain state for tests
-module Test.Nft.Init (
+module Test.NftStateMachine.Init (
   Script,
   runScript,
   checkOptions,

--- a/mlabs/test/Test/NftStateMachine/Logic.hs
+++ b/mlabs/test/Test/NftStateMachine/Logic.hs
@@ -1,5 +1,5 @@
 -- | Tests for logic of state transitions for aave prototype
-module Test.Nft.Logic (
+module Test.NftStateMachine.Logic (
   test,
 ) where
 


### PR DESCRIPTION
Renames legacy "Nft" test folder/module to fix folder name conflict on MacOS.