### PR TITLE
Use `adjustUnbalancedTx` when submitting

### DIFF
--- a/mlabs/mlabs-plutus-use-cases.cabal
+++ b/mlabs/mlabs-plutus-use-cases.cabal
@@ -191,6 +191,7 @@ library
     Mlabs.System.Console.PrettyLogger
     Mlabs.System.Console.Utils
     Mlabs.Utils.Wallet
+    Mlabs.Utils
     Mlabs.Plutus.Contracts.Currency
     Mlabs.IntegrationTest.TxBuilder
     Mlabs.IntegrationTest.Types

--- a/mlabs/src/Mlabs/Demo/Contract/Mint.hs
+++ b/mlabs/src/Mlabs/Demo/Contract/Mint.hs
@@ -46,6 +46,7 @@ import Ledger.Typed.Scripts qualified as Scripts
 import Ledger.Value (CurrencySymbol, TokenName)
 import Ledger.Value qualified as Value
 import Mlabs.Demo.Contract.Burn (burnScrAddress, burnValHash)
+import Mlabs.Utils qualified as Utils
 import Plutus.Contract as Contract
 import PlutusTx qualified
 import Schema (ToSchema)
@@ -127,7 +128,7 @@ mintContract (MintParams tn amt) = do
           (Datum $ PlutusTx.toBuiltinData ())
           payVal
           <> Constraints.mustMintValue forgeVal
-  ledgerTx <- submitTxConstraintsWith @Void lookups tx
+  ledgerTx <- Utils.submitTxConstraintsWithUnbalanced @Void lookups tx
   void $ awaitTxConfirmed $ Ledger.getCardanoTxId ledgerTx
 
 mintEndpoints :: Contract () MintSchema Text ()

--- a/mlabs/src/Mlabs/Governance/Contract/Server.hs
+++ b/mlabs/src/Mlabs/Governance/Contract/Server.hs
@@ -42,6 +42,7 @@ import Mlabs.Governance.Contract.Api qualified as Api
 import Mlabs.Governance.Contract.Validation (AssetClassGov (..), GovernanceDatum (..), GovernanceRedeemer (..))
 import Mlabs.Governance.Contract.Validation qualified as Validation
 import Mlabs.Plutus.Contract (getEndpoint, selectForever)
+import Mlabs.Utils qualified as Utils
 
 --import GHC.Base (Applicative(pure))
 
@@ -91,7 +92,7 @@ deposit gov (Api.Deposit amnt) = do
 
       xGovValue = Validation.xgovSingleton gov ownPkh amnt
 
-  ledgerTx <- Contract.submitTxConstraintsWith @Validation.Governance lookups tx
+  ledgerTx <- Utils.submitTxConstraintsWithUnbalanced @Validation.Governance lookups tx
   void $ Contract.awaitTxConfirmed $ getCardanoTxId ledgerTx
   Contract.logInfo @String $ printf "deposited %s GOV tokens" (show amnt)
 
@@ -123,7 +124,7 @@ withdraw gov (Api.Withdraw assets) = do
                   ]
               )
 
-  ledgerTx <- Contract.submitTxConstraintsWith @Validation.Governance lookups tx
+  ledgerTx <- Utils.submitTxConstraintsWithUnbalanced @Validation.Governance lookups tx
   void $ Contract.awaitTxConfirmed $ getCardanoTxId ledgerTx
   Contract.logInfo @String $ printf "withdrew %s GOV tokens" (show . sum $ map snd assets)
 
@@ -138,7 +139,7 @@ provideRewards gov (Api.ProvideRewards val) = do
         map
           ( \(pkh, prop) ->
               case pkh of
-                Just pkh' -> Just (pkh', Value $ fmap (round.(prop *).(% 1)) <$> getValue val)
+                Just pkh' -> Just (pkh', Value $ fmap (round . (prop *) . (% 1)) <$> getValue val)
                 Nothing -> Nothing
           )
           props
@@ -153,7 +154,7 @@ provideRewards gov (Api.ProvideRewards val) = do
           [ Constraints.otherScript $ Validation.govValidator gov
           ]
 
-  ledgerTx <- Contract.submitTxConstraintsWith @Validation.Governance lookups tx
+  ledgerTx <- Utils.submitTxConstraintsWithUnbalanced @Validation.Governance lookups tx
   void $ Contract.awaitTxConfirmed $ getCardanoTxId ledgerTx
   Contract.logInfo @String $ printf "Provided rewards to all xGOV holders"
   where

--- a/mlabs/src/Mlabs/NFT/Contract/BidAuction.hs
+++ b/mlabs/src/Mlabs/NFT/Contract/BidAuction.hs
@@ -32,6 +32,7 @@ import Plutus.V1.Ledger.Ada qualified as Ada
 import Mlabs.NFT.Contract.Aux
 import Mlabs.NFT.Types
 import Mlabs.NFT.Validation
+import Mlabs.Utils qualified as Utils
 
 {- |
   Attempts to bid on NFT auction, locks new bid in the script, returns previous bid to previous bidder,
@@ -98,7 +99,7 @@ bidAuction symbol (AuctionBidParams nftId bidAmount) = do
             ]
               ++ bidDependentTxConstraints
           )
-  void $ Contract.submitTxConstraintsWith @NftTrade lookups tx
+  void $ Utils.submitTxConstraintsWithUnbalanced @NftTrade lookups tx
   Contract.tell . Last . Just . Left $ nftId
   void $ Contract.logInfo @Hask.String $ printf "Bidding %s in auction for %s" (Hask.show bidAmount) (Hask.show nftVal)
   where

--- a/mlabs/src/Mlabs/NFT/Contract/Buy.hs
+++ b/mlabs/src/Mlabs/NFT/Contract/Buy.hs
@@ -30,6 +30,7 @@ import Mlabs.NFT.Contract.Aux
 import Mlabs.NFT.Contract.Fees
 import Mlabs.NFT.Types
 import Mlabs.NFT.Validation
+import Mlabs.Utils qualified as Utils
 
 {- | BUY.
  Attempts to buy a new NFT by changing the owner, pays the current owner and
@@ -87,7 +88,7 @@ buy symbol BuyRequestUser {..} = do
               (Redeemer . PlutusTx.toBuiltinData $ action)
           ]
             <> govTx
-  void $ Contract.submitTxConstraintsWith @NftTrade lookups tx
+  void $ Utils.submitTxConstraintsWithUnbalanced @NftTrade lookups tx
   Contract.tell . Last . Just . Left $ ur'nftId
   Contract.logInfo @Hask.String "buy successful!"
   where

--- a/mlabs/src/Mlabs/NFT/Contract/CloseAuction.hs
+++ b/mlabs/src/Mlabs/NFT/Contract/CloseAuction.hs
@@ -32,6 +32,7 @@ import Mlabs.NFT.Contract.Aux
 import Mlabs.NFT.Contract.Fees
 import Mlabs.NFT.Types
 import Mlabs.NFT.Validation
+import Mlabs.Utils qualified as Utils
 
 {- |
   Attempts to close NFT auction, checks if owner is closing an auction and deadline passed,
@@ -85,7 +86,7 @@ closeAuction symbol (AuctionCloseParams nftId) = do
           ]
             <> bidDependentTxConstraints
 
-  void $ Contract.submitTxConstraintsWith @NftTrade lookups tx
+  void $ Utils.submitTxConstraintsWithUnbalanced @NftTrade lookups tx
   Contract.tell . Last . Just . Left $ nftId
   void $ Contract.logInfo @Hask.String $ printf "Closing auction for %s" $ Hask.show nftVal
   where

--- a/mlabs/src/Mlabs/NFT/Contract/Init.hs
+++ b/mlabs/src/Mlabs/NFT/Contract/Init.hs
@@ -25,6 +25,7 @@ till it will be fixed, see `Mlabs.Plutus.Contracts.Currency.mintContract`
 for details -}
 import Mlabs.Plutus.Contracts.Currency (CurrencyError, mintContract)
 import Mlabs.Plutus.Contracts.Currency qualified as MC
+import Mlabs.Utils qualified as Utils
 
 import Plutus.V1.Ledger.Value (TokenName (..), assetClass, assetClassValue)
 import PlutusTx.Prelude hiding (mconcat, (<>))
@@ -94,7 +95,7 @@ createListHead admins = do
                 , Constraints.mustMintValueWithRedeemer govInitRedeemer govProofTokenValue
                 ]
             )
-      void $ Contract.submitTxConstraintsWith @NftTrade lookups tx
+      void $ Utils.submitTxConstraintsWithUnbalanced @NftTrade lookups tx
       Contract.logInfo @Hask.String $ printf "Forged Script Head & Governance Head for %s" (Hask.show appInstance)
       return appInstance
 

--- a/mlabs/src/Mlabs/NFT/Contract/Mint.hs
+++ b/mlabs/src/Mlabs/NFT/Contract/Mint.hs
@@ -28,6 +28,7 @@ import Ledger.Value as Value (TokenName (..), assetClass, assetClassValue, singl
 import Mlabs.NFT.Contract.Aux
 import Mlabs.NFT.Types
 import Mlabs.NFT.Validation
+import Mlabs.Utils qualified as Utils
 
 --------------------------------------------------------------------------------
 -- MINT --
@@ -48,7 +49,7 @@ mint symbol params = do
       (nLk, nCx) <- mintNode symbol nftPolicy newNode rNode
       let lookups = mconcat [lLk, nLk]
           tx = mconcat [lCx, nCx]
-      void $ Contract.submitTxConstraintsWith @NftTrade lookups tx
+      void $ Utils.submitTxConstraintsWithUnbalanced @NftTrade lookups tx
       Contract.tell . Last . Just . Left . info'id . node'information $ newNode
       Contract.logInfo @Hask.String $ printf "mint successful!"
   where
@@ -116,7 +117,7 @@ mint symbol params = do
       pure (lookups, tx)
       where
         token = Value.singleton (app'symbol appSymbol) (TokenName . getDatumValue . pi'data $ insertPoint) 1
-        newToken = assetClass (app'symbol appSymbol) (TokenName .getDatumValue . NodeDatum $ newNode)
+        newToken = assetClass (app'symbol appSymbol) (TokenName . getDatumValue . NodeDatum $ newNode)
         newDatum = updatePointer (Pointer newToken)
         oref = pi'TOR insertPoint
         redeemer = asRedeemer $ MintAct (NftId . getDatumValue . NodeDatum $ newNode) symbol

--- a/mlabs/src/Mlabs/NFT/Contract/OpenAuction.hs
+++ b/mlabs/src/Mlabs/NFT/Contract/OpenAuction.hs
@@ -30,6 +30,7 @@ import Ledger.Value qualified as Value
 import Mlabs.NFT.Contract.Aux
 import Mlabs.NFT.Types
 import Mlabs.NFT.Validation
+import Mlabs.Utils qualified as Utils
 
 {- |
   Attempts to start NFT auction, removes current price from NFT and starts auction.
@@ -73,7 +74,7 @@ openAuction symbol (AuctionOpenParams nftId deadline minBid) = do
               pi'TOR
               (Redeemer . PlutusTx.toBuiltinData $ action)
           ]
-  void $ Contract.submitTxConstraintsWith @NftTrade lookups tx
+  void $ Utils.submitTxConstraintsWithUnbalanced @NftTrade lookups tx
   Contract.tell . Last . Just . Left $ nftId
   void $ Contract.logInfo @Hask.String $ printf "Started auction for %s" $ Hask.show nftVal
   where

--- a/mlabs/src/Mlabs/NFT/Contract/SetPrice.hs
+++ b/mlabs/src/Mlabs/NFT/Contract/SetPrice.hs
@@ -34,6 +34,7 @@ import Ledger.Typed.Scripts (validatorScript)
 import Mlabs.NFT.Contract.Aux
 import Mlabs.NFT.Types
 import Mlabs.NFT.Validation
+import Mlabs.Utils qualified as Utils
 
 {- |
   Attempts to set price of NFT, checks if price is being set by the owner
@@ -72,7 +73,7 @@ setPrice symbol SetPriceParams {..} = do
               (Redeemer . PlutusTx.toBuiltinData $ action)
           ]
 
-  void $ Contract.submitTxConstraintsWith @NftTrade lookups tx
+  void $  Utils.submitTxConstraintsWithUnbalanced @NftTrade lookups tx
   Contract.tell . Last . Just . Left $ sp'nftId
   Contract.logInfo @Hask.String "set-price successful!"
   where

--- a/mlabs/src/Mlabs/Plutus/Contracts/Currency.hs
+++ b/mlabs/src/Mlabs/Plutus/Contracts/Currency.hs
@@ -43,6 +43,8 @@ import Schema (ToSchema)
 import Prelude (Semigroup (..))
 import Prelude qualified as Haskell
 
+import Mlabs.Utils qualified as Utils
+
 {- HLINT ignore "Use uncurry" -}
 
 -- | A currency that can be created exactly once
@@ -157,7 +159,8 @@ mintContract pkh amounts = mapError (review _CurrencyError) $ do
       mintTx =
         Constraints.mustSpendScriptOutput txOutRef unitRedeemer
           <> Constraints.mustMintValue (mintedValue theCurrency)
-  tx <- submitTxConstraintsWith @Scripts.Any lookups mintTx
+          <> Constraints.mustBeSignedBy pkh
+  tx <- Utils.submitTxConstraintsWithUnbalanced @Scripts.Any lookups mintTx
   _ <- awaitTxConfirmed (getCardanoTxId tx)
   pure theCurrency
 

--- a/mlabs/src/Mlabs/Utils.hs
+++ b/mlabs/src/Mlabs/Utils.hs
@@ -1,0 +1,31 @@
+module Mlabs.Utils (
+  submitTxConstraintsWithUnbalanced,
+) where
+
+import Data.Kind (Type)
+import Data.Row (Row)
+
+import Ledger (CardanoTx)
+import Ledger.Constraints (ScriptLookups, TxConstraints)
+import Ledger.Constraints qualified as Constraints
+import Ledger.Typed.Scripts (RedeemerType, ValidatorTypes (DatumType))
+
+import Plutus.Contract (Contract)
+import Plutus.Contract qualified as Contract
+import PlutusTx qualified
+
+import PlutusTx.Prelude
+
+submitTxConstraintsWithUnbalanced ::
+  forall a w (s :: Row Type) e.
+  ( PlutusTx.ToData (RedeemerType a)
+  , PlutusTx.FromData (DatumType a)
+  , PlutusTx.ToData (DatumType a)
+  , Contract.AsContractError e
+  ) =>
+  ScriptLookups a ->
+  TxConstraints (RedeemerType a) (DatumType a) ->
+  Contract w s e CardanoTx
+submitTxConstraintsWithUnbalanced lookups tx =
+  Contract.mkTxConstraints @a lookups tx
+    >>= Contract.submitUnbalancedTx . Constraints.adjustUnbalancedTx

--- a/mlabs/test/Test/NFT/QuickCheck.hs
+++ b/mlabs/test/Test/NFT/QuickCheck.hs
@@ -19,6 +19,7 @@ import Plutus.Contract.Test.ContractModel (
   ContractModel (..),
   contractState,
   currentSlot,
+  defaultCoverageOptions,
   deposit,
   getModelState,
   propRunActionsWithOptions,
@@ -372,6 +373,7 @@ propContract =
   QC.withMaxSuccess 50
     . propRunActionsWithOptions -- Keeping 50 tests limits time to ~1m, 100 tests took ~8m
       checkOptions
+      defaultCoverageOptions
       instanceSpec
       (const $ Hask.pure True)
 


### PR DESCRIPTION
- Use `adjustUnbalancedTx` when submitting
- Add `mustBeSignedBy` to one-shot minting policy
- Fix QuickCheck tests