### PR TITLE
Fix cabal

### DIFF
--- a/mlabs/nix/haskell.nix
+++ b/mlabs/nix/haskell.nix
@@ -57,6 +57,7 @@ pkgs.haskell-nix.cabalProject {
       measures
       orphans-deriving-via
       playground-common
+      plutus-chain-index
       plutus-contract
       plutus-core
       plutus-ledger


### PR DESCRIPTION
Fix missing `plutus-chain-index` package when using cabal
```
$ cabal repl
Warning: No remote package servers have been specified. Usually you would have
one specified in the config file.
Resolving dependencies...
cabal: Could not resolve dependencies:
[__0] trying: mlabs-plutus-use-cases-0.1.0.0 (user goal)
[__1] unknown package: plutus-chain-index (dependency of
mlabs-plutus-use-cases)
[__1] fail (backjumping, conflict set: mlabs-plutus-use-cases,
plutus-chain-index)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: mlabs-plutus-use-cases,
plutus-chain-index
```